### PR TITLE
Change to getDisplayValues for support return types

### DIFF
--- a/scripts/Server.js
+++ b/scripts/Server.js
@@ -27,7 +27,7 @@ var Server = (function(ns) {
     
     // get the sheet and data
     var sheet = SpreadsheetApp.getActiveSheet();
-    var data = sheet.getDataRange().getValues();
+    var data = sheet.getDataRange().getDisplayValues();
     
     // all done - but we'll return the data too 
     var now = new Date().getTime();


### PR DESCRIPTION
Dates can not get on the client. When there is a cell with a Date, we don't observe statistics because of an error there. Changed `getValues()` to `getDisplayValues()`